### PR TITLE
Initialize Vite React app for Lango

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Rename this file to .env and add your OpenAI key
+VITE_OPENAI_API_KEY=

--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # Lango
+
+A minimal language learning app built with React and Vite. Choose the language you speak, the one you want to learn and your level to generate a learning plan powered by the OpenAI API. The plan is presented as a series of flashcards you can step through.
+
+## Setup
+
+1. Copy `.env.example` to `.env` and add your `VITE_OPENAI_API_KEY`.
+2. Install dependencies:
+   ```bash
+   npm install
+   ```
+3. Start the development server:
+   ```bash
+   npm run dev
+   ```

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Lango</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+  </head>
+  <body class="min-h-screen bg-gray-50 flex items-center justify-center p-4">
+    <div id="root" class="w-full max-w-xl"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "lango",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "echo \"No tests specified\""
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,141 @@
+import { useState } from 'react';
+
+const languages = ['English', 'Spanish', 'French', 'German', 'Chinese'];
+const levels = ['Beginner', 'Intermediate', 'Advanced'];
+
+export default function App() {
+  const [nativeLang, setNativeLang] = useState('');
+  const [targetLang, setTargetLang] = useState('');
+  const [level, setLevel] = useState('Beginner');
+  const [plan, setPlan] = useState('');
+  const [cards, setCards] = useState([]);
+  const [currentCard, setCurrentCard] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const generatePlan = async () => {
+    setLoading(true);
+    setPlan('');
+    setCards([]);
+    setCurrentCard(0);
+    setError('');
+    try {
+      const res = await fetch('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${import.meta.env.VITE_OPENAI_API_KEY}`,
+        },
+        body: JSON.stringify({
+          model: 'gpt-3.5-turbo',
+          messages: [
+            { role: 'system', content: 'You are a helpful language tutor.' },
+            {
+              role: 'user',
+              content: `Create a ${level.toLowerCase()} ${targetLang} learning plan for someone who knows ${nativeLang}.`,
+            },
+          ],
+        }),
+      });
+      const data = await res.json();
+      const text = data.choices?.[0]?.message?.content || 'No plan generated.';
+      setPlan(text);
+      const stepCards = text.split(/\n+/).filter((l) => l.trim().length);
+      setCards(stepCards);
+    } catch {
+      setError('Failed to fetch plan.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="bg-white shadow p-6 rounded-lg">
+      <h1 className="text-2xl font-bold mb-4 text-center">Lango</h1>
+      <div className="space-y-4">
+        <div>
+          <label className="block mb-1">I speak</label>
+          <select
+            className="w-full border p-2 rounded"
+            value={nativeLang}
+            onChange={(e) => setNativeLang(e.target.value)}
+          >
+            <option value="" disabled>
+              Select language
+            </option>
+            {languages.map((lang) => (
+              <option key={lang} value={lang}>
+                {lang}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block mb-1">I want to learn</label>
+          <select
+            className="w-full border p-2 rounded"
+            value={targetLang}
+            onChange={(e) => setTargetLang(e.target.value)}
+          >
+            <option value="" disabled>
+              Select language
+            </option>
+            {languages.map((lang) => (
+              <option key={lang} value={lang}>
+                {lang}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block mb-1">Level</label>
+          <select
+            className="w-full border p-2 rounded"
+            value={level}
+            onChange={(e) => setLevel(e.target.value)}
+          >
+            {levels.map((lvl) => (
+              <option key={lvl} value={lvl}>
+                {lvl}
+              </option>
+            ))}
+          </select>
+        </div>
+        <button
+          className="w-full bg-blue-500 text-white p-2 rounded disabled:opacity-50"
+          onClick={generatePlan}
+          disabled={loading || !nativeLang || !targetLang}
+        >
+          {loading ? 'Generating...' : 'Generate Plan'}
+        </button>
+        {error && <p className="text-red-500">{error}</p>}
+        {cards.length > 0 && (
+          <div className="mt-4">
+            <div className="border rounded p-4 shadow min-h-[100px] mb-4">
+              {cards[currentCard]}
+            </div>
+            <div className="flex items-center justify-between text-sm">
+              <button
+                className="px-2 py-1 bg-gray-200 rounded disabled:opacity-50"
+                onClick={() => setCurrentCard((c) => c - 1)}
+                disabled={currentCard === 0}
+              >
+                Previous
+              </button>
+              <span>
+                {currentCard + 1} / {cards.length}
+              </span>
+              <button
+                className="px-2 py-1 bg-gray-200 rounded disabled:opacity-50"
+                onClick={() => setCurrentCard((c) => c + 1)}
+                disabled={currentCard === cards.length - 1}
+              >
+                Next
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- scaffold Vite React project
- add basic UI to select languages and level
- generate learning plans via OpenAI API
- present each plan step as navigable flashcards

## Testing
- `npm install` *(fails: 403 Forbidden - registry access)*
- `npm test`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6acfcf948332a78e10483c04b33d